### PR TITLE
upgrade to use contracts v1.0.9

### DIFF
--- a/scripts/augmint-cli.sh
+++ b/scripts/augmint-cli.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-DOCKER_IMAGE=augmint/contracts:v1.0.4
+DOCKER_IMAGE=augmint/contracts:v1.0.9
 CONTAINER_NAME=ganache
 
 echo ""


### PR DESCRIPTION
Upgraded from v1.0.4 to use latest v1.0.9 ganache docker image.

No contract (or abiniser) changes, just ganache-cli upgrade to v6.4.3. See [`augmint-contracts` release notes](https://github.com/Augmint/augmint-contracts/releases)

Nothing do to do on consumer side, `augmint-cli` will take care of pulling the latest docker image:
```
$ yarn ganache:start
yarn run v1.15.2
$ scripts/augmint-cli.sh ganache start

augmint-cli : start / stop augmint contracts. Docker image: augmint/contracts:v1.0.9

WARNING: ganache docker container image mismatch.
  There is already a docker container named 'ganache' using image augmint/contracts:v1.0.4.
  expected image is augmint/contracts:v1.0.9 for current augmint.js version.
  It's likely because of an augmint-js upgrade since last local run of container. Removing existing ganache container.
Container 'ganache' is running. Stopping.
ganache
ganache
Container 'ganache' doesn't exist. Using docker run to create and start.
Unable to find image 'augmint/contracts:v1.0.9' locally
v1.0.9: Pulling from augmint/contracts
48ecbb6b270e: Already exists 
ab00b628fcad: Already exists 
49295c836b82: Already exists 
5a3be5eb5295: Already exists 
5b28ce458cdb: Already exists 
218a1d838a95: Already exists 
c7ebdf787c0a: Already exists 
e5601c507407: Already exists 
be65e78ebf0a: Already exists 
7060d43eabc2: Already exists 
9cdd3dab212e: Already exists 
672564d85aa5: Pull complete 
Digest: sha256:c99101cdde117b4b36adf6ec5d7e64c1909db735c86efa1eea5801dc103157fa
Status: Downloaded newer image for augmint/contracts:v1.0.9
13093465f76dd85675c4f46af6c3cb3a47f583ac22e19a9153cf6c12e99a93d2
✨  Done in 7.13s.
```


