### PR TITLE
augmint-cli ganache launch extra flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@augmint/js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Augmint Javascript Library",
   "keywords": [
     "augmint javascript library A-EUR stablecoin web3 dapp"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "build:typings": "ts-generator ./ts-generator.json",
     "test": "yarn build && yarn cross-env NODE_ENV=test NODE_PATH=./  mocha 'test/**/*.test.js' --exit --timeout 5000",
     "ganache:start": "scripts/augmint-cli.sh ganache start",
-    "ganache:stop": "scripts/augmint-cli.sh ganache stop"
+    "ganache:stop": "scripts/augmint-cli.sh ganache stop",
+    "ganache:run": "scripts/augmint-cli.sh ganache run"
   },
   "greenkeeper": {
     "ignore": [

--- a/scripts/augmint-cli.sh
+++ b/scripts/augmint-cli.sh
@@ -13,8 +13,8 @@ fi
 
 function run_ganache {
     docker run --init --detach --name $CONTAINER_NAME -p 8545:8545 $DOCKER_IMAGE --db ./dockerLocalchaindb \
-                --gasLimit 0x47D5DE --gasPrice 1000000000 --networkId 999 --noVMErrorsOnRPCResponse \
-                -m "hello build tongue rack parade express shine salute glare rate spice stock"
+        --gasLimit 0x47D5DE --gasPrice 1000000000 --networkId 999 --noVMErrorsOnRPCResponse $ADDITIONAL_GANACHE_LAUNCH_FLAGS \
+        -m "hello build tongue rack parade express shine salute glare rate spice stock"
 }
 
 function stop_container_if_running {
@@ -41,7 +41,7 @@ function remove_container_if_image_mismatched {
 
 
 function print_instructions {
-    echo "    Usage: $0 ganache {start | stop | run}"
+    echo "    Usage: $0 ganache {start | stop | run} [<additional ganache launch flags. eg. --blockTime 1>]"
     echo "      start: tries to start container named $CONTAINER_NAME . If fails then runs (downloads, creates and starts) the container from $DOCKER_IMAGE"
     echo "      stop: plain docker stop $DOCKER_IMAGE (doesn't check if exists)"
     echo "      run: stops and removes the $CONTAINER_NAME container if exists. then runs it "
@@ -49,6 +49,9 @@ function print_instructions {
 
 case "$1" in
     ganache )
+
+        ADDITIONAL_GANACHE_LAUNCH_FLAGS=${@:3} 
+
         case "$2" in
             run )
                 remove_container_if_image_mismatched


### PR DESCRIPTION
- augmint-cli to accept extra params for ganache launch. Eg. when we need to run ganache with `--blockTime 1`  to auto mine (required for tests running against websocket) 
- `yarn ganache:run` script (shorthand to `augmint-cli ganache run` to recreate container)
