### PR TITLE
Rates test fixes

### DIFF
--- a/src/Rates.ts
+++ b/src/Rates.ts
@@ -37,12 +37,11 @@ export class Rates extends AbstractContract {
         this.web3 = this.ethereumConnection.web3;
         this.decimals = options.decimals;
         this.decimalsDiv = options.decimalsDiv;
-        this.constants = options.constants;
     }
 
     public async getBnEthFiatRate(currency: string): Promise<BigNumber> {
         const rate: string = await this.instance.methods
-            .convertFromWei(this.web3.utils.asciiToHex(currency), this.constants.ONE_ETH_IN_WEI.toString())
+            .convertFromWei(this.web3.utils.asciiToHex(currency), ONE_ETH_IN_WEI.toString())
             .call()
             .catch((error: Error) => {
                 if (error.message.includes("revert rates[bSymbol] must be > 0")) {
@@ -59,7 +58,7 @@ export class Rates extends AbstractContract {
 
     public async getEthFiatRate(currency: string): Promise<number> {
         const bnEthFiatRate: BigNumber = await this.getBnEthFiatRate(currency);
-        return parseFloat(bnEthFiatRate.div(this.constants.DECIMALS_DIV).toFixed(this.constants.DECIMALS));
+        return parseFloat(bnEthFiatRate.div(DECIMALS_DIV).toFixed(DECIMALS));
     }
 
     public async getAugmintRate(currency: string): Promise<IRateInfo> {
@@ -71,13 +70,13 @@ export class Rates extends AbstractContract {
 
         return {
             bnRate: new BigNumber(storedRateInfo.rate),
-            rate: parseInt(storedRateInfo.rate) / decimalsDiv, // TODO: change to augmintToken.decimalsDiv
+            rate: parseInt(storedRateInfo.rate) / decimalsDiv,
             lastUpdated: new Date(parseInt(storedRateInfo.lastUpdated) * 1000)
         };
     }
 
     public setRate(currency: string, price: number): Transaction {
-        const rateToSend: number = price * this.constants.DECIMALS_DIV;
+        const rateToSend: number = price * DECIMALS_DIV;
 
         if (Math.round(rateToSend) !== rateToSend) {
             throw new InvalidPriceError(

--- a/test/Rates.setters.test.js
+++ b/test/Rates.setters.test.js
@@ -1,6 +1,6 @@
 const assert = require("chai").assert;
 const { Augmint } = require("../dist/index.js");
-const { InvalidPriceError, AugmintJsError } = Augmint.Errors;
+const { InvalidPriceError } = Augmint.Errors;
 const loadEnv = require("./testHelpers/loadEnv.js");
 const config = loadEnv();
 
@@ -92,12 +92,6 @@ describe("Rates setters", () => {
     });
 
     it("setRate - invalid price", () => {
-        const expectedPrice = 1232.222;
-        try {
-            rates.setRate(CCY, expectedPrice);
-        } catch (error) {
-            assert.instanceOf(error, AugmintJsError);
-            assert.instanceOf(error, InvalidPriceError);
-        }
+        assert.throws(() => rates.setRate(CCY, 1232.222), InvalidPriceError);
     });
 });

--- a/test/Rates.test.js
+++ b/test/Rates.test.js
@@ -4,7 +4,6 @@ const { Augmint, utils } = require("../dist/index.js");
 const loadEnv = require("./testHelpers/loadEnv.js");
 const { takeSnapshot, revertSnapshot } = require("./testHelpers/ganache.js");
 
-const { AugmintJsError, ZeroRateError } = Augmint.Errors;
 const config = loadEnv();
 const CCY = "EUR";
 const DECIMALS_DIV = 100;
@@ -55,24 +54,10 @@ describe("Rates getters", () => {
         assert.equal(ethFiatRate, EXPECTED_RATE);
     });
 
-    it("getBnEthFiatRate - invalid ccy", async () => {
-        await myAugmint.rates.getEthFiatRate("INVALID").catch(error => {
-            assert.instanceOf(error, AugmintJsError);
-            assert.instanceOf(error, ZeroRateError);
-        });
-    });
-
     it("getAugmintRate", async () => {
         const augmintRate = await myAugmint.rates.getAugmintRate(CCY);
         assert.equal(augmintRate.rate, EXPECTED_RATE);
         assert.deepEqual(augmintRate.bnRate, new BigNumber(EXPECTED_RATE * DECIMALS_DIV));
         assert.instanceOf(augmintRate.lastUpdated, Date);
-    });
-
-    it("getAugmintRate - invalid ccy", async () => {
-        await myAugmint.rates.getAugmintRate("INVALID").catch(error => {
-            assert.instanceOf(error, AugmintJsError);
-            assert.instanceOf(error, ZeroRateError);
-        });
     });
 });


### PR DESCRIPTION
- removed unnecessary `constants` props from `Rates` class
- removed obsolete tests (which were not breaking because they were faulty)