### PR TITLE
Use integer BN representation for amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@augmint/contracts": "1.0.9",
-    "bignumber.js": "5.0.0",
     "bn.js": "4.11.8",
     "dotenv": "8.0.0",
     "ulog": "2.0.0-beta.6",
@@ -62,7 +61,6 @@
   },
   "greenkeeper": {
     "ignore": [
-      "bignumber.js"
     ]
   },
   "main": "dist/index.js",

--- a/src/Augmint.ts
+++ b/src/Augmint.ts
@@ -116,7 +116,6 @@ export class Augmint {
             this._exchange = new Exchange(exchangeContract.connect(this.web3), {
                 token: this.token,
                 rates: this.rates,
-                ONE_ETH_IN_WEI: constants.ONE_ETH_IN_WEI,
                 ethereumConnection: this.ethereumConnection
             });
         }

--- a/src/Augmint.ts
+++ b/src/Augmint.ts
@@ -6,7 +6,7 @@ import { DeployedContract, IDeploymentItem } from "./DeployedContract";
 import { DeployedEnvironment, ILatestContracts } from "./DeployedEnvironment";
 import * as Errors from "./Errors";
 import { EthereumConnection, IOptions } from "./EthereumConnection";
-import { Exchange } from "./Exchange";
+import { Exchange, IExchangeOptions } from "./Exchange";
 import * as gas from "./gas";
 import { Rates } from "./Rates";
 import { Transaction } from "./Transaction";
@@ -142,8 +142,7 @@ export class Augmint {
                 throw new Error("legacy contracts length mismatch!");
             }
         }
-        const options = {
-            decimalsDiv: this.token.decimalsDiv,
+        const options: IExchangeOptions = {
             token: this.token, // FIXME: This should come from the exchange contract's augmintToken property
             rates: this.rates,
             ethereumConnection: this.ethereumConnection

--- a/src/Augmint.ts
+++ b/src/Augmint.ts
@@ -146,7 +146,6 @@ export class Augmint {
             decimalsDiv: this.token.decimalsDiv,
             token: this.token, // FIXME: This should come from the exchange contract's augmintToken property
             rates: this.rates,
-            ONE_ETH_IN_WEI: constants.ONE_ETH_IN_WEI,
             ethereumConnection: this.ethereumConnection
         };
         return legacyContracts.map(

--- a/src/Augmint.ts
+++ b/src/Augmint.ts
@@ -104,12 +104,7 @@ export class Augmint {
             const ratesContract: DeployedContract<RatesInstance> = this.deployedEnvironment.getLatestContract(
                 AugmintContracts.Rates
             );
-            this._rates = new Rates(ratesContract.connect(this.web3), {
-                decimals: this.token.decimals,
-                decimalsDiv: this.token.decimalsDiv,
-                constants,
-                ethereumConnection: this.ethereumConnection
-            });
+            this._rates = new Rates(ratesContract.connect(this.web3), this.ethereumConnection);
         }
         return this._rates;
     }

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -18,15 +18,6 @@ export class ZeroRateError extends AugmintJsError {
 }
 
 // tslint:disable-next-line:max-classes-per-file
-export class InvalidPriceError extends AugmintJsError {
-    constructor(message: string) {
-        super(message);
-        this.name = InvalidPriceError.name;
-        Object.setPrototypeOf(this, InvalidPriceError.prototype);
-    }
-}
-
-// tslint:disable-next-line:max-classes-per-file
 export class TransactionError extends AugmintJsError {
     constructor(message: string) {
         super(message);

--- a/src/Exchange.ts
+++ b/src/Exchange.ts
@@ -278,6 +278,8 @@ export class Exchange extends AbstractContract {
             sellIds.push(sell.id);
             buyIds.push(buy.id);
 
+            // matching logic follows smart contract _fillOrder implementation
+            // see https://github.com/Augmint/augmint-contracts/blob/staging/contracts/Exchange.sol
             const price: BN = buy.id > sell.id ? sell.price : buy.price;
 
             const sellWei = sell.amount.mul(price).mul(E12).divRound(ethFiatRate);

--- a/src/Exchange.ts
+++ b/src/Exchange.ts
@@ -25,7 +25,7 @@ export interface IMatchingOrders {
     gasEstimate: number;
 }
 
-interface IOrder {
+export interface IOrder {
     id: number;
     maker: string;
     direction: OrderDirection;
@@ -35,7 +35,7 @@ interface IOrder {
 
 type IOrderTuple = [string, string, string, string]; /** result from contract: [id, maker, price, amount] */
 
-interface IExchangeOptions {
+export interface IExchangeOptions {
     token: AugmintToken;
     rates: Rates;
     ethereumConnection: EthereumConnection;

--- a/src/Exchange.ts
+++ b/src/Exchange.ts
@@ -1,10 +1,9 @@
-import BigNumber from "bignumber.js";
 import BN from "bn.js";
 import { Exchange as ExchangeInstance } from "../generated/index";
 import { TransactionObject } from "../generated/types/types";
 import { AbstractContract } from "./AbstractContract";
 import { AugmintToken } from "./AugmintToken";
-import { CHUNK_SIZE, DECIMALS, DECIMALS_DIV, LEGACY_CONTRACTS_CHUNK_SIZE, ONE_ETH_IN_WEI, PPM_DIV } from "./constants";
+import { CHUNK_SIZE, LEGACY_CONTRACTS_CHUNK_SIZE } from "./constants";
 import { EthereumConnection } from "./EthereumConnection";
 import { MATCH_MULTIPLE_ADDITIONAL_MATCH_GAS, MATCH_MULTIPLE_FIRST_MATCH_GAS, PLACE_ORDER_GAS } from "./gas";
 import { Rates } from "./Rates";
@@ -15,14 +14,9 @@ export enum OrderDirection {
     TOKEN_SELL /** Sell order: orderDirection is 1 in contract */
 }
 
-export type ISellOrder = IGenericOrder;
-export interface IBuyOrder extends IGenericOrder {
-    bnEthAmount: BigNumber /** Buy order bnAmount in ETH */;
-}
-
 export interface IOrderBook {
-    buyOrders: IBuyOrder[];
-    sellOrders: ISellOrder[];
+    buyOrders: IOrder[];
+    sellOrders: IOrder[];
 }
 
 export interface IMatchingOrders {
@@ -31,30 +25,19 @@ export interface IMatchingOrders {
     gasEstimate: number;
 }
 
-interface IGenericOrder {
+interface IOrder {
     id: number;
     maker: string;
     direction: OrderDirection;
-    bnAmount: BigNumber /** Buy order amount in Wei | Sell order amount in tokens, without decimals */;
-    amount: number /** Buy order amount in ETH | Sell order amount in tokens with decimals */;
-    bnPrice: BigNumber /** price in PPM (parts per million) | price in PPM (parts per million) */;
-    price: number /** price with decimals */;
+    amount: BN /** Buy order amount in Wei | Sell order amount in tokens, without decimals */;
+    price: BN /** price in PPM (parts per million) | price in PPM (parts per million) */;
 }
 
 type IOrderTuple = [string, string, string, string]; /** result from contract: [id, maker, price, amount] */
 
-interface IBuyOrderCalc extends IBuyOrder {
-    bnTokenValue?: BigNumber;
-}
-
-interface ISellOrderCalc extends ISellOrder {
-    bnEthValue?: BigNumber;
-}
-
 interface IExchangeOptions {
     token: AugmintToken;
     rates: Rates;
-    ONE_ETH_IN_WEI: number;
     ethereumConnection: EthereumConnection;
 }
 
@@ -71,8 +54,6 @@ export class Exchange extends AbstractContract {
     private token: AugmintToken;
     private tokenPeggedSymbol: Promise<string>;
     private rates: Rates;
-    private decimalsDiv: Promise<number>;
-    private ONE_ETH_IN_WEI: number;
     private ethereumConnection: EthereumConnection;
 
     constructor(deployedContractInstance: ExchangeInstance, options: IExchangeOptions) {
@@ -83,7 +64,6 @@ export class Exchange extends AbstractContract {
         this.safeBlockGasLimit = this.ethereumConnection.safeBlockGasLimit;
         this.rates = options.rates;
         this.token = options.token;
-        this.ONE_ETH_IN_WEI = options.ONE_ETH_IN_WEI;
     }
 
     /**
@@ -123,7 +103,7 @@ export class Exchange extends AbstractContract {
         const sellCount: number = parseInt(orderCounts.sellTokenOrderCount, 10);
 
         // retreive all orders
-        let buyOrders: IBuyOrder[] = [];
+        let buyOrders: IOrder[] = [];
         let queryCount: number = Math.ceil(buyCount / LEGACY_CONTRACTS_CHUNK_SIZE);
 
         for (let i: number = 0; i < queryCount; i++) {
@@ -131,7 +111,7 @@ export class Exchange extends AbstractContract {
             buyOrders = buyOrders.concat(fetchedOrders.buyOrders);
         }
 
-        let sellOrders: ISellOrder[] = [];
+        let sellOrders: IOrder[] = [];
         queryCount = Math.ceil(sellCount / chunkSize);
         for (let i: number = 0; i < queryCount; i++) {
             const fetchedOrders: IOrderBook = await this.getOrders(OrderDirection.TOKEN_SELL, i * chunkSize);
@@ -146,7 +126,6 @@ export class Exchange extends AbstractContract {
 
     public async getOrders(orderDirection: OrderDirection, offset: number): Promise<IOrderBook> {
         const blockGasLimit: number = this.safeBlockGasLimit;
-        const decimalsDiv = await this.token.decimalsDiv;
         // @ts-ignore  TODO: remove ts-ignore and handle properly when legacy contract support added
         const isLegacyExchangeContract: boolean = typeof this.instance.methods.CHUNK_SIZE === "function";
         const chunkSize: number = isLegacyExchangeContract ? LEGACY_CONTRACTS_CHUNK_SIZE : CHUNK_SIZE;
@@ -169,30 +148,21 @@ export class Exchange extends AbstractContract {
         // result format: [id, maker, price, amount]
         const orders: IOrderBook = result.reduce(
             (res: IOrderBook, order: IOrderTuple) => {
-                const bnAmount: BigNumber = new BigNumber(order[3]);
-                if (!bnAmount.eq(0)) {
-                    const bnPrice: BigNumber = new BigNumber(order[2]);
-                    const amount: number =
-                        orderDirection === OrderDirection.TOKEN_BUY
-                            ? parseFloat(bnAmount.div(this.ONE_ETH_IN_WEI).toFixed(15))
-                            : parseFloat(bnAmount.div(decimalsDiv).toFixed(2));
-                    const parsed: IGenericOrder = {
+                const amount: BN = new BN(order[3]);
+                if (!amount.isZero()) {
+                    const price: BN = new BN(order[2]);
+                    const parsed: IOrder = {
                         id: parseInt(order[0], 10),
-                        maker: `0x${new BigNumber(order[1]).toString(16).padStart(40, "0")}`, // leading 0s if address starts with 0
-                        bnPrice,
-                        bnAmount,
+                        maker: `0x${new BN(order[1]).toString(16).padStart(40, "0")}`, // leading 0s if address starts with 0
+                        price,
                         amount,
-                        price: parseFloat(bnPrice.div(PPM_DIV).toString()),
                         direction: orderDirection
                     };
 
                     if (orderDirection === OrderDirection.TOKEN_BUY) {
-                        const bnEthAmount: BigNumber = bnAmount.div(ONE_ETH_IN_WEI);
-                        const buyOrder: IBuyOrder = { ...parsed, bnEthAmount };
-
-                        res.buyOrders.push(buyOrder);
+                        res.buyOrders.push(parsed);
                     } else {
-                        res.sellOrders.push(parsed as ISellOrder);
+                        res.sellOrders.push(parsed);
                     }
                 }
                 return res;
@@ -230,14 +200,14 @@ export class Exchange extends AbstractContract {
         return transaction;
     }
 
-    public isOrderBetter(o1: IGenericOrder, o2: IGenericOrder): number {
+    public isOrderBetter(o1: IOrder, o2: IOrder): number {
         if (o1.direction !== o2.direction) {
             throw new Error("isOrderBetter(): order directions must be the same" + o1 + o2);
         }
 
-        const dir: number = o1.direction === OrderDirection.TOKEN_SELL ? 1 : -1;
+        const dir: BN = o1.direction === OrderDirection.TOKEN_SELL ? new BN(1) : new BN(-1);
 
-        return o1.price * dir > o2.price * dir || (o1.price === o2.price && o1.id > o2.id) ? 1 : -1;
+        return o1.price.mul(dir).gt(o2.price.mul(dir)) || (o1.price.eq(o2.price) && o1.id > o2.id) ? 1 : -1;
     }
 
     /**
@@ -275,8 +245,8 @@ export class Exchange extends AbstractContract {
      * @return {object}                pairs of matching order id , ordered by execution sequence { buyIds: [], sellIds: [], gasEstimate }
      */
     public calculateMatchingOrders(
-        _buyOrders: IBuyOrder[],
-        _sellOrders: ISellOrder[],
+        _buyOrders: IOrder[],
+        _sellOrders: IOrder[],
         ethFiatRate: BN,
         gasLimit: number
     ): IMatchingOrders {
@@ -286,75 +256,49 @@ export class Exchange extends AbstractContract {
         if (_buyOrders.length === 0 || _sellOrders.length === 0) {
             return { buyIds, sellIds, gasEstimate: 0 };
         }
-        const lowestSellPrice: BigNumber = _sellOrders[0].bnPrice;
-        const highestBuyPrice: BigNumber = _buyOrders[0].bnPrice;
+        const lowestSellPrice: BN = _sellOrders[0].price;
+        const highestBuyPrice: BN = _buyOrders[0].price;
 
-        const buyOrders: IBuyOrderCalc[] = _buyOrders
-            .filter((o: IBuyOrder) => o.bnPrice.gte(lowestSellPrice))
-            .map((o: IBuyOrderCalc) => o as IBuyOrderCalc);
+        const buyOrders: IOrder[] = _buyOrders
+            .filter((o: IOrder) => o.price.gte(lowestSellPrice));
 
-        const sellOrders: ISellOrderCalc[] = _sellOrders
-            .filter((o: ISellOrder) => o.bnPrice.lte(highestBuyPrice))
-            .map((o: ISellOrderCalc) => o as ISellOrderCalc);
+        const sellOrders: IOrder[] = _sellOrders
+            .filter((o: IOrder) => o.price.lte(highestBuyPrice));
 
         let buyIdx: number = 0;
         let sellIdx: number = 0;
         let gasEstimate: number = 0;
         let nextGasEstimate: number = MATCH_MULTIPLE_FIRST_MATCH_GAS;
 
+        const E12 = new BN("1000000000000");
         while (buyIdx < buyOrders.length && sellIdx < sellOrders.length && nextGasEstimate <= gasLimit) {
-            const sellOrder: ISellOrderCalc = sellOrders[sellIdx];
-            const buyOrder: IBuyOrderCalc = buyOrders[buyIdx];
-            sellIds.push(sellOrder.id);
-            buyIds.push(buyOrder.id);
 
-            let tradedEth: BigNumber;
-            let tradedTokens: BigNumber;
+            const sell: IOrder = sellOrders[sellIdx];
+            const buy: IOrder = buyOrders[buyIdx];
+            sellIds.push(sell.id);
+            buyIds.push(buy.id);
 
-            const bnMatchPrice: BigNumber = buyOrder.id > sellOrder.id ? sellOrder.bnPrice : buyOrder.bnPrice;
+            const price: BN = buy.id > sell.id ? sell.price : buy.price;
 
-            buyOrder.bnTokenValue = new BigNumber(ethFiatRate)
-                .mul(PPM_DIV)
-                .div(bnMatchPrice)
-                .mul(buyOrder.bnEthAmount)
-                .round();
+            const sellWei = sell.amount.mul(price).mul(E12).divRound(ethFiatRate);
 
-            sellOrder.bnEthValue = sellOrder.bnAmount
-                .mul(bnMatchPrice)
-                .div(ethFiatRate)
-                .div(PPM_DIV);
-
-            if (sellOrder.bnAmount.lt(buyOrder.bnTokenValue)) {
-                tradedEth = sellOrder.bnEthValue;
-                tradedTokens = sellOrder.bnAmount;
+            let tradedWei: BN;
+            let tradedTokens: BN;
+            if (sellWei.lte(buy.amount)) {
+                tradedWei = sellWei;
+                tradedTokens = sell.amount;
             } else {
-                tradedEth = buyOrder.bnEthAmount;
-                tradedTokens = buyOrder.bnTokenValue;
+                tradedWei = buy.amount;
+                tradedTokens = buy.amount.mul(ethFiatRate).divRound(price.mul(E12));
             }
 
-            //     const DECIMALS_DIV = 100; // in order debug to work with tests (instead of this.augmintToken.decimalsDiv)
-            //     console.debug(
-            //         `MATCH:  BUY: id: ${buyOrder.id} bnPrice: ${buyOrder.bnPrice.div(PPM_DIV)}% Amount: ${
-            //             buyOrder.bnEthAmount
-            //         } ETH tokenValue: ${buyOrder.bnTokenValue.div(DECIMALS_DIV)}
-            // SELL: id: ${sellOrder.id} bnPrice: ${sellOrder.bnPrice.div(PPM_DIV)}% Amount: ${sellOrder.bnAmount.div(
-            //             DECIMALS_DIV
-            //         )} AEUR  ethValue: ${sellOrder.bnEthValue}
-            // Traded: ${tradedEth.toString()} ETH <-> ${tradedTokens.div(DECIMALS_DIV)} AEUR @${bnMatchPrice.div(
-            //             PPM_DIV
-            //         )}% on ${bnEthFiatRate.div(DECIMALS_DIV)} ETHEUR`
-            //     );
-
-            buyOrder.bnEthAmount = buyOrder.bnEthAmount.sub(tradedEth);
-            buyOrder.bnTokenValue = buyOrder.bnTokenValue.sub(tradedTokens);
-
-            if (buyOrder.bnEthAmount.eq(0)) {
+            buy.amount = buy.amount.sub(tradedWei);
+            if (buy.amount.isZero()) {
                 buyIdx++;
             }
 
-            sellOrder.bnEthValue = sellOrder.bnEthValue.sub(tradedEth);
-            sellOrder.bnAmount = sellOrder.bnAmount.sub(tradedTokens);
-            if (sellOrder.bnAmount.eq(0)) {
+            sell.amount = sell.amount.sub(tradedTokens);
+            if (sell.amount.isZero()) {
                 sellIdx++;
             }
 

--- a/src/Rates.ts
+++ b/src/Rates.ts
@@ -40,7 +40,7 @@ export class Rates extends AbstractContract {
                 }
             });
 
-        return rate;
+        return new BN(rate);
     }
 
     public async getAugmintRate(currency: string): Promise<IRateInfo> {
@@ -50,7 +50,7 @@ export class Rates extends AbstractContract {
             .call();
 
         return {
-            rate: storedRateInfo.rate,
+            rate: new BN(storedRateInfo.rate),
             lastUpdated: new Date(parseInt(storedRateInfo.lastUpdated) * 1000)
         };
     }

--- a/src/Rates.ts
+++ b/src/Rates.ts
@@ -1,92 +1,65 @@
-import BigNumber from "bignumber.js";
+import BN from "bn.js";
 import { Rates as RatesInstance } from "../generated/index";
 import { TransactionObject } from "../generated/types/types";
 import { AbstractContract } from "./AbstractContract";
-import { DECIMALS, DECIMALS_DIV, ONE_ETH_IN_WEI } from "./constants";
-import { InvalidPriceError, ZeroRateError } from "./Errors";
+import { ONE_ETH_IN_WEI } from "./constants";
+import { ZeroRateError } from "./Errors";
 import { EthereumConnection } from "./EthereumConnection";
 import { SET_RATE_GAS_LIMIT } from "./gas";
 import { Transaction } from "./Transaction";
 
 export interface IRateInfo {
-    bnRate: BigNumber /** The rate without decimals */;
-    rate: number /** rate with token decimals */;
+    rate: BN;
     lastUpdated: Date;
-}
-
-export interface IRatesOptions {
-    decimals: Promise<number>;
-    decimalsDiv: Promise<number>;
-    constants: any;
-    ethereumConnection: EthereumConnection;
 }
 
 export class Rates extends AbstractContract {
     // overwrite Contract's  property to have typings
     public instance: RatesInstance; /** web3.js Rates contract instance  */
     private web3: any;
-    private decimals: Promise<number>;
-    private decimalsDiv: Promise<number>;
-    private constants: any;
     private ethereumConnection: EthereumConnection;
 
-    constructor(deployedContractInstance: RatesInstance, options: IRatesOptions) {
+    constructor(deployedContractInstance: RatesInstance, ethereumConnection: EthereumConnection) {
         super(deployedContractInstance);
         this.instance = deployedContractInstance;
-        this.ethereumConnection = options.ethereumConnection;
+        this.ethereumConnection = ethereumConnection;
         this.web3 = this.ethereumConnection.web3;
-        this.decimals = options.decimals;
-        this.decimalsDiv = options.decimalsDiv;
     }
 
-    public async getBnEthFiatRate(currency: string): Promise<BigNumber> {
+    public async getEthFiatRate(currency: string): Promise<BN> {
         const rate: string = await this.instance.methods
             .convertFromWei(this.web3.utils.asciiToHex(currency), ONE_ETH_IN_WEI.toString())
             .call()
             .catch((error: Error) => {
                 if (error.message.includes("revert rates[bSymbol] must be > 0")) {
                     throw new ZeroRateError(
-                        `getBnEthFiatRate returned zero rate for currency: ${currency}. Is it supported and has rate set in Rates contract?`
+                        `getEthFiatRate returned zero rate for currency: ${currency}. Is it supported and has rate set in Rates contract?`
                     );
                 } else {
                     throw error;
                 }
             });
 
-        return new BigNumber(rate);
-    }
-
-    public async getEthFiatRate(currency: string): Promise<number> {
-        const bnEthFiatRate: BigNumber = await this.getBnEthFiatRate(currency);
-        return parseFloat(bnEthFiatRate.div(DECIMALS_DIV).toFixed(DECIMALS));
+        return rate;
     }
 
     public async getAugmintRate(currency: string): Promise<IRateInfo> {
-        const decimalsDiv: number = await this.decimalsDiv;
         const bytesCCY: string = this.web3.utils.asciiToHex(currency);
         const storedRateInfo: { rate: string; lastUpdated: string } = await this.instance.methods
             .rates(bytesCCY)
             .call();
 
         return {
-            bnRate: new BigNumber(storedRateInfo.rate),
-            rate: parseInt(storedRateInfo.rate) / decimalsDiv,
+            rate: storedRateInfo.rate,
             lastUpdated: new Date(parseInt(storedRateInfo.lastUpdated) * 1000)
         };
     }
 
-    public setRate(currency: string, price: number): Transaction {
-        const rateToSend: number = price * DECIMALS_DIV;
-
-        if (Math.round(rateToSend) !== rateToSend) {
-            throw new InvalidPriceError(
-                ` getSetRateTx error: provided price of ${price} has more decimals than allowed by AugmintToken decimals of ${DECIMALS}`
-            );
-        }
+    public setRate(currency: string, price: BN): Transaction {
 
         const bytesCCY: string = this.web3.utils.asciiToHex(currency);
 
-        const web3Tx: TransactionObject<void> = this.instance.methods.setRate(bytesCCY, rateToSend);
+        const web3Tx: TransactionObject<void> = this.instance.methods.setRate(bytesCCY, price.toString());
         const transaction: Transaction = new Transaction(this.ethereumConnection, web3Tx, {
             gasLimit: SET_RATE_GAS_LIMIT,
             // setting to: in case it's going to be signed

--- a/test/Exchange.test.js
+++ b/test/Exchange.test.js
@@ -1,5 +1,5 @@
 const { expect, assert } = require("chai");
-const BigNumber = require("bignumber.js");
+const BN = require("bn.js");
 const { takeSnapshot, revertSnapshot } = require("./testHelpers/ganache.js");
 const { Augmint, utils } = require("../dist/index.js");
 const loadEnv = require("./testHelpers/loadEnv.js");
@@ -46,14 +46,14 @@ describe("getOrderBook", () => {
         const buyMaker = myAugmint.ethereumConnection.accounts[1];
         const sellMaker = myAugmint.ethereumConnection.accounts[0];
         const buyPrice = 1.01;
-        const bnBuyPrice = new BigNumber(buyPrice * Augmint.constants.PPM_DIV);
+        const bnBuyPrice = new BN(buyPrice * Augmint.constants.PPM_DIV);
         const sellPrice = 1.05;
-        const bnSellPrice = new BigNumber(sellPrice * Augmint.constants.PPM_DIV);
+        const bnSellPrice = new BN(sellPrice * Augmint.constants.PPM_DIV);
 
         const buyEthAmount = 0.1;
-        const bn_buyWeiAmount = new BigNumber(myAugmint.ethereumConnection.web3.utils.toWei(buyEthAmount.toString()));
+        const bn_buyWeiAmount = new BN(myAugmint.ethereumConnection.web3.utils.toWei(buyEthAmount.toString()));
         const sellTokenAmount = 10;
-        const bn_sellTokenAmount = new BigNumber(sellTokenAmount * Augmint.constants.DECIMALS_DIV);
+        const bn_sellTokenAmount = new BN(sellTokenAmount * Augmint.constants.DECIMALS_DIV);
 
         await exchange.instance.methods
             .placeBuyTokenOrder(bnBuyPrice.toString())
@@ -70,23 +70,18 @@ describe("getOrderBook", () => {
                 {
                     id: 1,
                     maker: buyMaker.toLowerCase(),
-                    bnPrice: bnBuyPrice,
-                    bnAmount: bn_buyWeiAmount,
-                    price: buyPrice,
+                    price: bnBuyPrice,
+                    amount: bn_buyWeiAmount,
                     direction: Augmint.constants.OrderDirection.TOKEN_BUY,
-                    bnEthAmount: new BigNumber(buyEthAmount),
-                    amount: buyEthAmount
                 }
             ],
             sellOrders: [
                 {
                     id: 2,
                     maker: sellMaker.toLowerCase(),
-                    bnPrice: bnSellPrice,
-                    bnAmount: bn_sellTokenAmount,
-                    price: sellPrice,
+                    price: bnSellPrice,
+                    amount: bn_sellTokenAmount,
                     direction: Augmint.constants.OrderDirection.TOKEN_SELL,
-                    amount: sellTokenAmount
                 }
             ]
         });
@@ -100,44 +95,44 @@ describe("isOrderBetter", () => {
         exchange = myAugmint.exchange;
     });
     it("o2 should be better (SELL price)", () => {
-        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 2, id: 1 };
-        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 1, id: 2 };
+        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(2), id: 1 };
+        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(1), id: 2 };
         const result = exchange.isOrderBetter(o1, o2);
         expect(result).to.be.equal(1);
     });
 
     it("o1 should be better (BUY price)", () => {
-        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: 2, id: 2 };
-        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: 1, id: 1 };
+        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: new BN(2), id: 2 };
+        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: new BN(1), id: 1 };
         const result = exchange.isOrderBetter(o1, o2);
         expect(result).to.be.equal(-1);
     });
 
     it("o2 should be better (SELL id)", () => {
-        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 1, id: 2 };
-        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 1, id: 1 };
+        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(1), id: 2 };
+        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(1), id: 1 };
         const result = exchange.isOrderBetter(o1, o2);
         expect(result).to.be.equal(1);
     });
 
     it("o2 should be better (BUY id)", () => {
-        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: 1, id: 2 };
-        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: 1, id: 1 };
+        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: new BN(1), id: 2 };
+        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: new BN(1), id: 1 };
         const result = exchange.isOrderBetter(o1, o2);
         expect(result).to.be.equal(1);
     });
 
     it("o1 should be better when o1 same as o2", () => {
         // same id for two orders, it shouldn't happen
-        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 1, id: 1 };
-        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 1, id: 1 };
+        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(1), id: 1 };
+        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(1), id: 1 };
         const result = exchange.isOrderBetter(o1, o2);
         expect(result).to.be.equal(-1);
     });
 
     it("the direction of the two orders should be same", () => {
-        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: 2, id: 2 };
-        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: 1, id: 1 };
+        const o1 = { direction: Augmint.constants.OrderDirection.TOKEN_SELL, price: new BN(2), id: 2 };
+        const o2 = { direction: Augmint.constants.OrderDirection.TOKEN_BUY, price: new BN(1), id: 1 };
         expect(() => exchange.isOrderBetter(o1, o2)).to.throw(/order directions must be the same/);
     });
 });

--- a/test/Rates.setters.test.js
+++ b/test/Rates.setters.test.js
@@ -1,6 +1,6 @@
 const assert = require("chai").assert;
 const { Augmint } = require("../dist/index.js");
-const { InvalidPriceError } = Augmint.Errors;
+const BN = require("bn.js");
 const loadEnv = require("./testHelpers/loadEnv.js");
 const config = loadEnv();
 
@@ -34,7 +34,7 @@ describe("Rates setters", () => {
     });
 
     it("setRate - send", async () => {
-        const expectedPrice = 1234.56;
+        const expectedPrice = new BN(1234.56 * DECIMALS_DIV);
 
         const tx = rates.setRate(CCY, expectedPrice);
         const txReceipt = await tx.send({ from: accounts[0] }).getTxReceipt();
@@ -42,7 +42,7 @@ describe("Rates setters", () => {
 
         await assertEvent(rates.instance, "RateChanged", {
             symbol: BYTES_CCY.padEnd(66, "0"),
-            newRate: (expectedPrice * DECIMALS_DIV).toString()
+            newRate: expectedPrice.toString()
         });
 
         const newStoredRate = await rates.getAugmintRate(CCY);
@@ -53,7 +53,7 @@ describe("Rates setters", () => {
     it("setRate - signed", async () => {
         // private key of accounts[0] 0x76e7a 0aec3e43211395bbbb6fa059bd6750f83c3with the hardcoded mnemonin for ganache
         const PRIVATE_KEY = "0x85b3d743fbe4ec4e2b58947fa5484da7b2f5538b0ae8e655646f94c95d5fb949";
-        const expectedPrice = 5678.91;
+        const expectedPrice = new BN(5678.91 * DECIMALS_DIV);
 
         const txReceipt = await rates
             .setRate(CCY, expectedPrice)
@@ -67,7 +67,7 @@ describe("Rates setters", () => {
 
         await assertEvent(rates.instance, "RateChanged", {
             symbol: BYTES_CCY.padEnd(66, "0"),
-            newRate: (expectedPrice * DECIMALS_DIV).toString()
+            newRate: expectedPrice.toString()
         });
 
         const newStoredRate = await rates.getAugmintRate(CCY);
@@ -76,7 +76,7 @@ describe("Rates setters", () => {
     });
 
     it("setRate = 0", async () => {
-        const expectedPrice = 0;
+        const expectedPrice = new BN(0 * DECIMALS_DIV);
 
         const tx = rates.setRate(CCY, expectedPrice);
         const txReceipt = await tx.send({ from: accounts[0] }).getTxReceipt();
@@ -84,14 +84,11 @@ describe("Rates setters", () => {
         assert(txReceipt.status);
         await assertEvent(rates.instance, "RateChanged", {
             symbol: BYTES_CCY.padEnd(66, "0"),
-            newRate: (expectedPrice * DECIMALS_DIV).toString()
+            newRate: expectedPrice.toString()
         });
 
         const newStoredRate = await rates.getAugmintRate(CCY);
         assert.equal(newStoredRate.rate, expectedPrice);
     });
 
-    it("setRate - invalid price", () => {
-        assert.throws(() => rates.setRate(CCY, 1232.222), InvalidPriceError);
-    });
 });

--- a/test/Rates.setters.test.js
+++ b/test/Rates.setters.test.js
@@ -47,7 +47,7 @@ describe("Rates setters", () => {
 
         const newStoredRate = await rates.getAugmintRate(CCY);
 
-        assert.equal(newStoredRate.rate, expectedPrice);
+        assert(expectedPrice.eq(newStoredRate.rate));
     });
 
     it("setRate - signed", async () => {
@@ -72,7 +72,7 @@ describe("Rates setters", () => {
 
         const newStoredRate = await rates.getAugmintRate(CCY);
 
-        assert.equal(newStoredRate.rate, expectedPrice);
+        assert(expectedPrice.eq(newStoredRate.rate));
     });
 
     it("setRate = 0", async () => {
@@ -88,7 +88,7 @@ describe("Rates setters", () => {
         });
 
         const newStoredRate = await rates.getAugmintRate(CCY);
-        assert.equal(newStoredRate.rate, expectedPrice);
+        assert(expectedPrice.eq(newStoredRate.rate));
     });
 
 });

--- a/test/Rates.test.js
+++ b/test/Rates.test.js
@@ -1,5 +1,5 @@
 const { assert } = require("chai");
-const BigNumber = require("bignumber.js");
+const BN = require("bn.js");
 const { Augmint, utils } = require("../dist/index.js");
 const loadEnv = require("./testHelpers/loadEnv.js");
 const { takeSnapshot, revertSnapshot } = require("./testHelpers/ganache.js");
@@ -23,7 +23,7 @@ describe("Rates connection", () => {
 });
 
 describe("Rates getters", () => {
-    const EXPECTED_RATE = 213.14;
+    const EXPECTED_RATE = new BN(213.14 * DECIMALS_DIV);
     let snapshotId;
     let myAugmint;
 
@@ -35,18 +35,13 @@ describe("Rates getters", () => {
         const BYTES_CCY = myAugmint.ethereumConnection.web3.utils.asciiToHex(CCY);
         const rates = myAugmint.rates;
 
-        await rates.instance.methods.setRate(BYTES_CCY, EXPECTED_RATE * DECIMALS_DIV).send({
+        await rates.instance.methods.setRate(BYTES_CCY, EXPECTED_RATE.toString()).send({
             from: myAugmint.ethereumConnection.accounts[0]
         });
     });
 
     after(async () => {
         await revertSnapshot(myAugmint.ethereumConnection.web3, snapshotId);
-    });
-
-    it("getBnEthFiatRate", async () => {
-        const bnEthFiatRate = await myAugmint.rates.getBnEthFiatRate(CCY);
-        assert.deepEqual(bnEthFiatRate, new BigNumber(EXPECTED_RATE * DECIMALS_DIV));
     });
 
     it("getEthFiatRate", async () => {
@@ -57,7 +52,6 @@ describe("Rates getters", () => {
     it("getAugmintRate", async () => {
         const augmintRate = await myAugmint.rates.getAugmintRate(CCY);
         assert.equal(augmintRate.rate, EXPECTED_RATE);
-        assert.deepEqual(augmintRate.bnRate, new BigNumber(EXPECTED_RATE * DECIMALS_DIV));
         assert.instanceOf(augmintRate.lastUpdated, Date);
     });
 });

--- a/test/Rates.test.js
+++ b/test/Rates.test.js
@@ -46,12 +46,12 @@ describe("Rates getters", () => {
 
     it("getEthFiatRate", async () => {
         const ethFiatRate = await myAugmint.rates.getEthFiatRate(CCY);
-        assert.equal(ethFiatRate, EXPECTED_RATE);
+        assert(EXPECTED_RATE.eq(ethFiatRate));
     });
 
     it("getAugmintRate", async () => {
         const augmintRate = await myAugmint.rates.getAugmintRate(CCY);
-        assert.equal(augmintRate.rate, EXPECTED_RATE);
+        assert(EXPECTED_RATE.eq(augmintRate.rate));
         assert.instanceOf(augmintRate.lastUpdated, Date);
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,11 +315,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bignumber.js@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-5.0.0.tgz#fbce63f09776b3000a83185badcde525daf34833"
-  integrity sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==
-
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"


### PR DESCRIPTION
Fixes #44 
This is a breaking change in the following interfaces:
- `Rates.getEthFiatRate` : renamed and returns `BN` instead of `BigNumber`
- `Rates.getAugmintRate` : returns `BN` for `.rate` instead of `BigNumber`
- `Exchange.getOrderBook` : returns a different object, numbers only `BN`s
- `Exchange.matchMultipleOrders` : accepts Orders in new format from `getOrderBook`