### PR TITLE
Parse real-world units

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@augmint/js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Augmint Javascript Library",
   "keywords": [
     "augmint javascript library A-EUR stablecoin web3 dapp"

--- a/src/units.ts
+++ b/src/units.ts
@@ -72,6 +72,10 @@ abstract class FixedPoint {
     // conversion
     //
 
+    public zeroToNull(): this | null {
+        return this.isZero() ? null : this;
+    }
+
     public toJSON(): string {
         return this.toString();
     }
@@ -103,7 +107,7 @@ export class Wei extends FixedPoint {
     static readonly DIV_PRECISON: BN = Wei.DIV_BN.divn(Wei.PRECISION);
 
     public static parse(str: string): Wei {
-        return new Wei(new BN(str));
+        return new Wei(new BN(str.toString()));
     }
 
     public static of(num: number): Wei {
@@ -128,7 +132,7 @@ export class Tokens extends FixedPoint {
     static readonly DIV: number = 100;
 
     public static parse(str: string): Tokens {
-        return new Tokens(new BN(str));
+        return new Tokens(new BN(str.toString()));
     }
 
     public static of(num: number): Tokens {
@@ -164,7 +168,7 @@ export class Ratio extends FixedPoint {
     static readonly DIV_BN: BN = new BN(Ratio.DIV);
 
     public static parse(str: string): Ratio {
-        return new Ratio(new BN(str));
+        return new Ratio(new BN(str.toString()));
     }
 
     public static of(num: number): Ratio {

--- a/test/units.test.js
+++ b/test/units.test.js
@@ -8,7 +8,7 @@ describe("Units", () => {
             assert.throws(() => new Type());
             assert.throws(() => new Type(null));
         })
-     });
+    });
 
     it("no operations accross types", () => {
         assert.throws(() => Wei.of(1).add(Tokens.of(100)));
@@ -21,7 +21,12 @@ describe("Units", () => {
         assert.equal(Tokens.of(100.01).toString(16), "2711");
         assert.equal(Ratio.of(1.01).toNumber(), 1.01);
         assert.equal(JSON.stringify({ tokens: Tokens.of(100.01) }), '{"tokens":"10001"}');
-    });
+        assert.equal("10001", Tokens.parse("10001").toString());
+        assert.equal("10001", Tokens.parse(10001).toString());
+        assert.throws(() => Tokens.parse(null));    
+        assert.isNull(Tokens.parse("0").zeroToNull());
+        assert.equal("10001", Tokens.parse(10001).zeroToNull().toString());
+     });
 
     it("rounds Ratio properly", () => {
         assert.equal(Ratio.of(1.025).toString(), "1025000")


### PR DESCRIPTION
- `parse(...)` should allow non-strings
- add `zeroToNull()` convenience method
